### PR TITLE
[receiver/statsdreceiver] Add support for parsing dogstatsd multi value lines

### DIFF
--- a/.chloggen/statsdreceiver_support_multivalue_dogstatsd_lines.yaml
+++ b/.chloggen/statsdreceiver_support_multivalue_dogstatsd_lines.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for multivalue DogStatsD metrics as described by the DogStatsD v1.1 protocol.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
@@ -302,13 +302,14 @@ func Test_ParseMessageToMetric(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, false, false)
+			got, err := parseMessageToMetrics(tt.input, false, false)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, got)
+				assert.Len(t, got, 1)
+				assert.Equal(t, tt.wantMetric, got[0])
 			}
 		})
 	}
@@ -530,13 +531,14 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, true, false)
+			got, err := parseMessageToMetrics(tt.input, true, false)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, got)
+				assert.Len(t, got, 1)
+				assert.Equal(t, tt.wantMetric, got[0])
 			}
 		})
 	}
@@ -595,13 +597,14 @@ func Test_ParseMessageToMetricWithSimpleTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, false, true)
+			got, err := parseMessageToMetrics(tt.input, false, true)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, got)
+				assert.Len(t, got, 1)
+				assert.Equal(t, tt.wantMetric, got[0])
 			}
 		})
 	}

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
@@ -311,10 +311,10 @@ func Test_ParseMessageToMetric(t *testing.T) {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, 1, got.len())
-				metric, err := got.metric(0)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, metric)
+				res, err := got.All()
+				require.NoError(t, err)
+				require.Len(t, res, 1)
+				assert.Equal(t, tt.wantMetric, res[0])
 			}
 		})
 	}
@@ -543,10 +543,10 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, 1, got.len())
-				metric, err := got.metric(0)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, metric)
+				res, err := got.All()
+				require.NoError(t, err)
+				require.Len(t, res, 1)
+				assert.Equal(t, tt.wantMetric, res[0])
 			}
 		})
 	}
@@ -611,10 +611,10 @@ func Test_ParseMessageToMetricWithSimpleTags(t *testing.T) {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, 1, got.len())
-				metric, err := got.metric(0)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.wantMetric, metric)
+				res, err := got.All()
+				require.NoError(t, err)
+				require.Len(t, res, 1)
+				assert.Equal(t, tt.wantMetric, res[0])
 			}
 		})
 	}
@@ -2082,14 +2082,8 @@ func Test_ParseMessageWithMultipleValuesToMetric(t *testing.T) {
 				assert.ErrorContainsf(t, err, tt.wantErr, "")
 			} else {
 				assert.NoError(t, err)
-
-				var metrics []statsDMetric
-				for i := 0; i < got.len(); i++ {
-					metric, err := got.metric(i)
-					assert.NoError(t, err)
-					metrics = append(metrics, metric)
-				}
-
+				metrics, err := got.All()
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantMetrics, metrics)
 			}
 		})
@@ -2143,11 +2137,6 @@ func firstStatsDMetricIterError(iter statsDMetricIter, iterErr error) error {
 	if iterErr != nil {
 		return iterErr
 	}
-	for i := 0; i < iter.len(); i++ {
-		_, err := iter.metric(i)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := iter.All()
+	return err
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
dogstatsd [v1.1 protocol](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11) allows specifying multiple values in a single datagram. This adds support for multiple values, converting them into multiple metrics with a single value each.

#### Testing
Added unit tests coverage for parsing multiple values

#### Documentation
None added
