### PR TITLE
prometheusreceiver: Convert VictoriaMetrics histograms to ExponentialHistograms

### DIFF
--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -39,7 +39,11 @@ var (
 	errTransactionAborted = errors.New("transaction aborted")
 	errNoJobInstance      = errors.New("job or instance cannot be found from labels")
 
-	notUsefulLabelsHistogram = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.BucketLabel})
+	// Note: Including vmHistogramRangeLabel here means that if a prom classic histogram happens to have
+	// a "vmrange" label, it may not be properly grouped. Unfortunately, at the point where we use this list
+	// to compute getSeriesRef(), we don't know yet whether the metric is a prom classic histogram or a VM histogram
+	// so we have to take that risk.
+	notUsefulLabelsHistogram = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.BucketLabel, vmHistogramRangeLabel})
 	notUsefulLabelsSummary   = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel, model.QuantileLabel})
 	notUsefulLabelsOther     = sortString([]string{model.MetricNameLabel, model.InstanceLabel, model.SchemeLabel, model.MetricsPathLabel, model.JobLabel})
 )

--- a/receiver/prometheusreceiver/internal/vm_histograms.go
+++ b/receiver/prometheusreceiver/internal/vm_histograms.go
@@ -1,0 +1,84 @@
+package internal
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// This file contains logic for handling VictoriaMetrics Histograms.
+// See: https://docs.victoriametrics.com/victoriametrics/keyconcepts/#histogram
+
+const (
+	vmHistogramRangeLabel = "vmrange"
+)
+
+var (
+	errInvalidVMHistogramRange = errors.New("invalid 'vmrange' label value on histogram bucket")
+)
+
+func vmHistogramParseRange(vmrange string) (start, end float64, err error) {
+	before, after, ok := strings.Cut(vmrange, "...")
+	if !ok {
+		return 0, 0, errInvalidVMHistogramRange
+	}
+	start, err = strconv.ParseFloat(before, 64)
+	if err != nil {
+		return 0, 0, errInvalidVMHistogramRange
+	}
+	end, err = strconv.ParseFloat(after, 64)
+	if err != nil {
+		return 0, 0, errInvalidVMHistogramRange
+	}
+	return start, end, nil
+}
+
+func vmHistogramGetScale(start, end float64) int32 {
+	// Compute "scale" as per the OTLP spec:
+	//   https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-scale
+	//
+	//  base = 2**(2**(-scale)) = end / start
+	return int32(math.Round(-math.Log2(math.Log2(end / start))))
+}
+
+func vmConvertBuckets(dest pmetric.ExponentialHistogramDataPoint, source []*dataPoint) {
+	// base is the multiplier from one bucket boundary to the next:
+	//   base = 2**(2**(-scale))
+	// To calculate a logarithm with a base of "base", we'll use the formula:
+	//   log_base(x) = log2(x) / log2(base)
+	// So what we actually want to know is log2(base) = 2**(-scale)
+	log2base := math.Pow(2, float64(-dest.Scale()))
+
+	offsetInitialized := false
+	for _, dp := range source {
+		if dp.boundary == 0 {
+			dest.SetZeroCount(uint64(dp.value))
+			continue
+		}
+
+		// Calculate the index of the bucket given:
+		//   boundary = base**(index+1)
+		// So:
+		//   index = log_base(boundary) - 1 = log2(boundary) / log2(base) - 1
+		index := int32(math.Round(math.Log2(dp.boundary)/log2base - 1))
+
+		// Initialize the offset to the index of the first non-zero boundary.
+		if !offsetInitialized {
+			offsetInitialized = true
+			dest.Positive().SetOffset(index)
+		}
+
+		// Buckets are dense, starting at the offset, so we may need to fill in zeros.
+		position := int(index - dest.Positive().Offset())
+		for dest.Positive().BucketCounts().Len() <= position {
+			dest.Positive().BucketCounts().Append(0)
+		}
+
+		// Add to the existing value in case inexact (non-base-2) boundaries cause
+		// us to merge multiple source buckets into one destination bucket.
+		dest.Positive().BucketCounts().SetAt(position, dest.Positive().BucketCounts().At(position)+uint64(dp.value))
+	}
+}

--- a/receiver/prometheusreceiver/internal/vm_histograms_test.go
+++ b/receiver/prometheusreceiver/internal/vm_histograms_test.go
@@ -1,0 +1,192 @@
+package internal
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestVMHistogramParseRange(t *testing.T) {
+	tests := []struct {
+		vmrange   string
+		wantStart float64
+		wantEnd   float64
+		wantErr   bool
+	}{
+		{
+			vmrange:   "4.084e+02...4.642e+02",
+			wantStart: 4.084e+02,
+			wantEnd:   4.642e+02,
+		},
+		{
+			vmrange:   "0...0.000e+00",
+			wantStart: 0,
+			wantEnd:   0,
+		},
+		{
+			vmrange:   "0...0",
+			wantStart: 0,
+			wantEnd:   0,
+		},
+		{
+			vmrange:   "0...1.000e-09",
+			wantStart: 0,
+			wantEnd:   1e-9,
+		},
+		{
+			vmrange:   "-Inf...0",
+			wantStart: math.Inf(-1),
+			wantEnd:   0,
+		},
+		{
+			vmrange:   "1.000e+18...+Inf",
+			wantStart: 1e18,
+			wantEnd:   math.Inf(1),
+		},
+		{
+			vmrange: "",
+			wantErr: true,
+		},
+		{
+			vmrange: "1...",
+			wantErr: true,
+		},
+		{
+			vmrange: "1.0e...10",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.vmrange, func(t *testing.T) {
+			gotStart, gotEnd, err := vmHistogramParseRange(tt.vmrange)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("vmHistogramParseRange() expected error but got none")
+					return
+				}
+				if !errors.Is(err, errInvalidVMHistogramRange) {
+					t.Errorf("vmHistogramParseRange() error = %v, expected %v", err, errInvalidVMHistogramRange)
+					return
+				}
+			} else {
+				if err != nil {
+					t.Errorf("vmHistogramParseRange() unexpected error = %v", err)
+					return
+				}
+			}
+
+			if gotStart != tt.wantStart {
+				t.Errorf("vmHistogramParseRange() start = %v, want %v", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("vmHistogramParseRange() end = %v, want %v", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestVMHistogramGetScale(t *testing.T) {
+	tests := []struct {
+		vmrange   string
+		wantScale int32
+	}{
+		// Examples of conventional VM Histogram base-10 boundaries.
+		// These map to the closest scale but they're not exact.
+		{vmrange: "4.642e+01...5.275e+01", wantScale: 2},
+		{vmrange: "4.084e+02...4.642e+02", wantScale: 2},
+		// Exact matches to base-2 boundaries.
+		{vmrange: "1...4", wantScale: -1},
+		{vmrange: "1...2", wantScale: 0},
+		{vmrange: "1...1.41421", wantScale: 1},
+		{vmrange: "1...1.18921", wantScale: 2},
+		{vmrange: "1...1.09051", wantScale: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.vmrange, func(t *testing.T) {
+			start, end, err := vmHistogramParseRange(tt.vmrange)
+			if err != nil {
+				t.Errorf("vmHistogramParseRange() unexpected error = %v", err)
+			}
+			gotScale := vmHistogramGetScale(start, end)
+			if gotScale != tt.wantScale {
+				t.Errorf("vmHistogramGetScale() = %v, want %v", gotScale, tt.wantScale)
+			}
+		})
+	}
+}
+
+func TestVMConvertBuckets(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        []*dataPoint
+		scale         int32
+		wantZeroCount uint64
+		wantOffset    int32
+		wantCounts    []uint64
+	}{
+		{
+			name: "basic test case",
+			source: []*dataPoint{
+				{boundary: 0, value: 5},  // zero count
+				{boundary: 2, value: 10}, // index = 0
+				{boundary: 4, value: 15}, // index = 1
+			},
+			scale: 0, // base = 2
+
+			wantZeroCount: 5,
+			wantOffset:    0,
+			wantCounts:    []uint64{10, 15},
+		},
+		{
+			name: "scale 3 with offset and skipped bucket",
+			source: []*dataPoint{
+				{boundary: 0, value: 5},        // zero count
+				{boundary: 1.54221, value: 10}, // index = 4
+				{boundary: 1.83401, value: 15}, // index = 6
+			},
+			scale: 3, // base = 1.09051
+
+			wantZeroCount: 5,
+			wantOffset:    4,
+			wantCounts:    []uint64{10, 0, 15},
+		},
+		{
+			name: "VM base-10 boundaries forced into scale 2",
+			source: []*dataPoint{
+				{boundary: 0, value: 5},          // zero count
+				{boundary: 4.642e+02, value: 10}, // closest index = 34 (actual boundary = 430.6)
+				{boundary: 5.995e+02, value: 15}, // closest index = 36 (actual boundary = 608.9)
+				{boundary: 1.000e+03, value: 20}, // closest index = 39 (actual boundary = 1024)
+			},
+			scale:         2, // base = 1.18921 (vs. source VM base of 1.136)
+			wantZeroCount: 5,
+			wantOffset:    34,
+			wantCounts:    []uint64{10, 0, 15, 0, 0, 20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := pmetric.NewExponentialHistogramDataPoint()
+			dest.SetScale(tt.scale)
+
+			vmConvertBuckets(dest, tt.source)
+
+			if dest.ZeroCount() != tt.wantZeroCount {
+				t.Errorf("vmConvertBuckets() zero count = %v, want %v", dest.ZeroCount(), tt.wantZeroCount)
+			}
+			if dest.Positive().Offset() != tt.wantOffset {
+				t.Errorf("vmConvertBuckets() offset = %v, want %v", dest.Positive().Offset(), tt.wantOffset)
+			}
+			if !reflect.DeepEqual(dest.Positive().BucketCounts().AsRaw(), tt.wantCounts) {
+				t.Errorf("vmConvertBuckets() bucket counts = %v, want %v", dest.Positive().BucketCounts().AsRaw(), tt.wantCounts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a prototype branch that teaches the Prometheus receiver to understand [VictoriaMetrics Histograms](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#histogram) and convert them into [OTLP ExponentialHistogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram) datapoints.

Some more background on how VM histograms work can be found in [this blog post](https://valyala.medium.com/improving-histogram-usability-for-prometheus-and-grafana-bc7e5df0e350).

For now, we intentionally don't try to be smart about minimizing the error introduced by converting from VM's base-10 exponential bucket boundaries to OTLP's base-2 boundaries. For example, we don't try to distribute counts across multiple buckets when the source and destination bucket ranges overlap. Instead, we just try to find the destination bucket whose "end" value is closest (in either direction -- up or down) to the "end" value of the source bucket, and map all of the source bucket's count there.

The goal for this initial prototype is that the conversion should be error-free if the user reconfigures their VM histograms to use base-2 boundaries that exactly correspond to one of the `scale` values supported by OTLP.

Note: We do not intend to merge this PR into our fork's `main` branch. This is just a convenient way to review the branch. If this experiment works out, we may propose this change to the upstream OTel repo. However, it would probably need more clean-up (e.g. adding feature flags, documentation) to get into shape for that.