### PR TITLE
prometheusreceiver: Estimate missing sum for VM histograms

### DIFF
--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -11,6 +11,10 @@ import (
 type dataPoint struct {
 	value    float64
 	boundary float64
+
+	// prevBoundary is only used for VictoriaMetrics histograms. Since they can be sparse,
+	// we can't rely on the previous boundary being included in the list.
+	prevBoundary float64
 }
 
 // internalMetricMetadata allows looking up metadata for internal scrape metrics


### PR DESCRIPTION
VictoriaMetrics histogram functions like `histogram_avg()` don't rely on the `_sum` series so in practice users don't always report it. Instead, VM's `histogram_avg()` computes an approximate average from the `_bucket` series by assuming the average value of observations in each bucket is the average of the bucket's start and end boundaries.

https://github.com/VictoriaMetrics/VictoriaMetrics/blob/b98e5927525ceb3238870701ea9c7dcf6296681d/app/vmselect/promql/transform.go#L806-L809

The PromQL `histogram_avg()` function relies on `_sum` and `_count` to give an exact average. When the `_sum` series is missing, the average is reported as zero. To ease the migration from VM to PromQL, this PR fills in any missing sums in VM histograms with the same estimated sum that VM would compute. If the user later begins reporting a `_sum` series, that more accurate value will take precedence.