### PR TITLE
Fix and mark invalid vmhist metrics

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -273,6 +273,23 @@ func (mg *metricGroup) vmToExponentialHistogramDataPoints(dest pmetric.Exponenti
 			point.SetSum(vmEstimateSum(mg.complexValue))
 		}
 		vmConvertBuckets(point, mg.complexValue)
+
+		// Enforce that the count field must equal the sum of all bucket counts.
+		// This is a temporary workaround to try to prevent bad histogram data from causing a whole
+		// batch of metrics to be rejected by the backend.
+		bucketTotal := point.ZeroCount()
+		for i := 0; i < point.Positive().BucketCounts().Len(); i++ {
+			bucketTotal += point.Positive().BucketCounts().At(i)
+		}
+		for i := 0; i < point.Negative().BucketCounts().Len(); i++ {
+			bucketTotal += point.Negative().BucketCounts().At(i)
+		}
+		if point.Count() != bucketTotal {
+			// For now as part of debugging, we will force the count to pass the server-side validation.
+			// We'll add a special attribute so we can see which datapoints were affected.
+			point.Attributes().PutStr("vmhist_invalid_original_count", "true")
+			point.SetCount(bucketTotal)
+		}
 	}
 
 	// The timestamp MUST be in retrieved from milliseconds and converted to nanoseconds.

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -983,6 +983,39 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 				return point
 			},
 		},
+		{
+			name:                "VictoriaMetrics Histogram with inconsistent count",
+			metricName:          "vm_rows_read_per_query",
+			intervalStartTimeMs: 11,
+			labels:              labels.FromMap(map[string]string{"a": "A", "b": "B"}),
+			// This is the example from the VictoriaMetrics docs:
+			//   https://docs.victoriametrics.com/victoriametrics/keyconcepts/#histogram
+			scrapes: []*scrape{
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "4.084e+02...4.642e+02"}, value: 2},
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "5.275e+02...5.995e+02"}, value: 1},
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 1},
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
+				{at: 11, metric: "vm_rows_read_per_query_sum", value: 15582},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 123}, // This doesn't match the buckets.
+			},
+			want: func() pmetric.ExponentialHistogramDataPoint {
+				point := pmetric.NewExponentialHistogramDataPoint()
+				point.SetCount(11) // This gets fixed during conversion to OTLP.
+				point.SetSum(15582)
+				point.SetTimestamp(pcommon.Timestamp(11 * time.Millisecond))      // the time in milliseconds -> nanoseconds.
+				point.SetStartTimestamp(pcommon.Timestamp(11 * time.Millisecond)) // the time in milliseconds -> nanoseconds.
+				point.SetScale(2)
+				point.Positive().SetOffset(34)
+				point.Positive().BucketCounts().FromRaw([]uint64{2, 0, 1, 0, 0, 1, 0, 0, 3, 4})
+				attributes := point.Attributes()
+				// Since the count was fixed, we expect an attribute that indicates the correction.
+				attributes.PutStr("vmhist_invalid_original_count", "true")
+				attributes.PutStr("a", "A")
+				attributes.PutStr("b", "B")
+				return point
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Enforce that the count field must equal the sum of all bucket counts. This is a temporary workaround to try to prevent bad histogram data from causing a whole batch of metrics to be rejected by the backend.

For now as part of debugging, we will force the count to pass the server-side validation. We'll add a special attribute (`vmhist_invalid_original_count`) so we can see which datapoints were affected.