### PR TITLE
prometheusreceiver: Aggregate duplicate VM histograms

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -467,7 +467,11 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 	case pmetric.MetricTypeHistogram, pmetric.MetricTypeSummary:
 		switch {
 		case strings.HasSuffix(metricName, metricsSuffixSum):
-			mg.sums = append(mg.sums, v)
+			// We really only need to populate "sums" for VM histograms, but we can't tell the difference
+			// until we see a bucket series, so we populate it for all histograms just in case.
+			if mf.mtype == pmetric.MetricTypeHistogram {
+				mg.sums = append(mg.sums, v)
+			}
 			mg.sum = v
 			mg.hasSum = true
 		case strings.HasSuffix(metricName, metricsSuffixCount):

--- a/receiver/prometheusreceiver/internal/vm_histograms.go
+++ b/receiver/prometheusreceiver/internal/vm_histograms.go
@@ -79,6 +79,9 @@ func vmConvertBuckets(dest pmetric.ExponentialHistogramDataPoint, source []*data
 
 		// Add to the existing value in case inexact (non-base-2) boundaries cause
 		// us to merge multiple source buckets into one destination bucket.
+		// This also happens to aggregate buckets from multiple VM histograms in a single scrape
+		// that have the same metric name and label set. The instrumentation library isn't supposed
+		// to do that, but if they do then aggregating seems like a graceful way to handle it.
 		dest.Positive().BucketCounts().SetAt(position, dest.Positive().BucketCounts().At(position)+uint64(dp.value))
 	}
 }


### PR DESCRIPTION
Some instrumentation libraries have been found to allow exposition of multiple VM histograms in a single scrape that have the same metric name and label set. We were already accidentally aggregating buckets correctly in that degenerate case, but then the counts and sums didn't match the bucket values.

To solidify the accidental mitigation for duplicate VM histograms, this PR adds explicit support for aggregation of count and sum so that they match the buckets which were already being aggregated.