### PR TITLE
[prometheusreceiver] aggregate on zero-bucket vmhistogram counts

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -931,17 +931,19 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 			// This is the example from the VictoriaMetrics docs:
 			//   https://docs.victoriametrics.com/victoriametrics/keyconcepts/#histogram
 			scrapes: []*scrape{
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "0...0.000e+00"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "4.084e+02...4.642e+02"}, value: 2},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "5.275e+02...5.995e+02"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
 				{at: 11, metric: "vm_rows_read_per_query_sum", value: 15582},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 11},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
 			},
 			want: func() pmetric.ExponentialHistogramDataPoint {
 				point := pmetric.NewExponentialHistogramDataPoint()
-				point.SetCount(11)
+				point.SetCount(12)
+				point.SetZeroCount(1)
 				point.SetSum(15582)
 				point.SetTimestamp(pcommon.Timestamp(11 * time.Millisecond))      // the time in milliseconds -> nanoseconds.
 				point.SetStartTimestamp(pcommon.Timestamp(11 * time.Millisecond)) // the time in milliseconds -> nanoseconds.
@@ -960,16 +962,18 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 			intervalStartTimeMs: 11,
 			labels:              labels.FromMap(map[string]string{"a": "A", "b": "B"}),
 			scrapes: []*scrape{
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "0...0.000e+00"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "4.084e+02...4.642e+02"}, value: 2},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "5.275e+02...5.995e+02"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 11},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
 			},
 			want: func() pmetric.ExponentialHistogramDataPoint {
 				point := pmetric.NewExponentialHistogramDataPoint()
-				point.SetCount(11)
+				point.SetCount(12)
+				point.SetZeroCount(1)
 				// sum is estimated due to missing _sum series
 				point.SetSum(15180.05)
 				point.SetTimestamp(pcommon.Timestamp(11 * time.Millisecond))      // the time in milliseconds -> nanoseconds.
@@ -993,24 +997,27 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 			// We try to handle this gracefully by aggregating across all matching histograms.
 			scrapes: []*scrape{
 				// The first histogram.
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "0...0.000e+00"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "4.084e+02...4.642e+02"}, value: 2},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "5.275e+02...5.995e+02"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
 				{at: 11, metric: "vm_rows_read_per_query_sum", value: 1000},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 11},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
 
 				// Another overlapping histogram in the same scrape.
+				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "0...0.000e+00"}, value: 10},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 10},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 30},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 40},
 				{at: 11, metric: "vm_rows_read_per_query_sum", value: 2000},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 80},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 90},
 			},
 			want: func() pmetric.ExponentialHistogramDataPoint {
 				point := pmetric.NewExponentialHistogramDataPoint()
-				point.SetCount(11 + 80)
+				point.SetCount(12 + 90)
+				point.SetZeroCount(1 + 10)
 				point.SetSum(1000 + 2000)
 				point.SetTimestamp(pcommon.Timestamp(11 * time.Millisecond))      // the time in milliseconds -> nanoseconds.
 				point.SetStartTimestamp(pcommon.Timestamp(11 * time.Millisecond)) // the time in milliseconds -> nanoseconds.

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -938,7 +938,7 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
 				{at: 11, metric: "vm_rows_read_per_query_sum", value: 15582},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 1}, // count from _count line is ignored for vmhist
 			},
 			want: func() pmetric.ExponentialHistogramDataPoint {
 				point := pmetric.NewExponentialHistogramDataPoint()
@@ -968,7 +968,7 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "8.799e+02...1.000e+03"}, value: 1},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 1}, // count from _count line is ignored for vmhist
 			},
 			want: func() pmetric.ExponentialHistogramDataPoint {
 				point := pmetric.NewExponentialHistogramDataPoint()
@@ -1004,7 +1004,7 @@ func TestMetricGroupData_vmToExponentialHistogramUnitTest(t *testing.T) {
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.468e+03...1.668e+03"}, value: 3},
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "1.896e+03...2.154e+03"}, value: 4},
 				{at: 11, metric: "vm_rows_read_per_query_sum", value: 1000},
-				{at: 11, metric: "vm_rows_read_per_query_count", value: 12},
+				{at: 11, metric: "vm_rows_read_per_query_count", value: 1}, // count from _count line is ignored for vmhist
 
 				// Another overlapping histogram in the same scrape.
 				{at: 11, metric: "vm_rows_read_per_query_bucket", extraLabel: labels.Label{Name: "vmrange", Value: "0...0.000e+00"}, value: 10},

--- a/receiver/prometheusreceiver/internal/vm_histograms.go
+++ b/receiver/prometheusreceiver/internal/vm_histograms.go
@@ -55,7 +55,7 @@ func vmConvertBuckets(dest pmetric.ExponentialHistogramDataPoint, source []*data
 	offsetInitialized := false
 	for _, dp := range source {
 		if dp.boundary == 0 {
-			dest.SetZeroCount(uint64(dp.value))
+			dest.SetZeroCount(dest.ZeroCount() + uint64(dp.value))
 			continue
 		}
 

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1775,3 +1775,81 @@ scrape_configs:
 	require.Contains(t, gotUA, set.BuildInfo.Command)
 	require.Contains(t, gotUA, set.BuildInfo.Version)
 }
+
+const vmHistoPayload = `
+# TYPE test_vmhisto histogram
+test_vmhisto_bucket{foo="bar",vmrange="0...0.000e+00"} 1
+test_vmhisto_bucket{foo="bar",vmrange="4.084e+02...4.642e+02"} 2
+test_vmhisto_bucket{foo="bar",vmrange="5.275e+02...5.995e+02"} 3
+test_vmhisto_count{foo="bar"} 123456
+# TYPE test_counter counter
+test_counter_total{foo="bar"} 123.0
+`
+
+const vmHistPayloadDupes = `
+# TYPE test_vmhisto histogram
+test_vmhisto_bucket{foo="bar",vmrange="0...0.000e+00"} 1
+test_vmhisto_bucket{foo="bar",vmrange="4.084e+02...4.642e+02"} 2
+test_vmhisto_bucket{foo="bar",vmrange="5.275e+02...5.995e+02"} 3
+test_vmhisto_count{foo="bar"} 123456
+# TYPE test_counter counter
+test_counter_total{foo="bar"} 123.0
+# TYPE test_vmhisto histogram
+test_vmhisto_bucket{foo="bar",vmrange="0...0.000e+00"} 100
+test_vmhisto_bucket{foo="bar",vmrange="4.084e+02...4.642e+02"} 200
+test_vmhisto_bucket{foo="bar",vmrange="5.275e+02...5.995e+02"} 300
+test_vmhisto_count{foo="bar"} 123456
+`
+
+func TestVMHisto(t *testing.T) {
+	getDataFn := func(name string, useOM bool, testPage string, expectedCount int) *testData {
+		return &testData{
+			name: "vm_histogram_response",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: testPage, useOpenMetrics: useOM},
+			},
+			validateFunc: func(t *testing.T, td *testData, result []pmetric.ResourceMetrics) {
+				metrics := getMetrics(result[0])
+				for _, m := range metrics {
+					if m.Name() == "test_vmhisto" {
+						histo := m.ExponentialHistogram()
+						require.Equal(t, 1, histo.DataPoints().Len())
+						// _count is not used
+						require.Equal(t, expectedCount, int(histo.DataPoints().At(0).Count()))
+						return
+					}
+				}
+				// vmhisto just outright fails with om-parser
+				if !td.pages[0].useOpenMetrics {
+					t.Fatalf("did not find expected test_vmhisto")
+				}
+			},
+			validateScrapes: true,
+		}
+	}
+
+	for _, useOM := range []bool{false, true} {
+		for _, testCase := range []struct {
+			name          string
+			payload       string
+			expectedCount int
+		}{
+			{
+				"no dupe histo",
+				vmHistoPayload,
+				1 + 2 + 3,
+			},
+			{
+				"with dupe histo",
+				vmHistPayloadDupes,
+				1 + 2 + 3 + 100 + 200 + 300,
+			},
+		} {
+			t.Run(fmt.Sprintf("%s useOM=%v", testCase.name, useOM), func(t *testing.T) {
+				t.Parallel()
+				in := getDataFn(testCase.name, useOM, testCase.payload, testCase.expectedCount)
+				testComponent(t, []*testData{in}, nil)
+			})
+		}
+	}
+}


### PR DESCRIPTION
`prometheusreceiver` should also account for duplicate scrapes of the zero boundary bucket for vm histograms.
Add a higher level unit test suite that exercises the actual prom-scrape loop.